### PR TITLE
Use Github's markdown rendering

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,4 +11,4 @@ twitter_username: jekyllrb
 github_username:  jekyll
 
 # Build settings
-markdown: kramdown
+markdown: redcarpet


### PR DESCRIPTION
GFM is basically the defacto standard for Markdown these days. Since most Jekyll pages will probably be used by Github pages it'd be nice to also support GFM ootb