### PR TITLE
Navigation

### DIFF
--- a/404.md
+++ b/404.md
@@ -1,0 +1,8 @@
+---
+layout: page
+title: 404 - Page not found
+---
+
+Sorry, we can't find that page that you're looking for. You can try take for a look by going [back to the homepage]({{ site.baseurl }}/).
+
+[<img src="//assets.ubuntu.com/sites/ubuntu/1576/u/img/error/image-404.svg" alt="Error owl" style="width: 365px;"/>]({{ site.baseurl }}/)

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -11,7 +11,7 @@
         </div>
         <ul>
           {% for page in site.pages %}
-            {% if page.title %}
+            {% if page.title and page.nav %}
             <li><a href="{{ page.url | prepend: site.baseurl }}">{{ page.title }}</a></li>
             {% endif %}
           {% endfor %}

--- a/about.md
+++ b/about.md
@@ -2,6 +2,7 @@
 layout: page
 title: About
 permalink: /about/
+nav: true
 ---
 
 This is the base Jekyll theme. You can find out more info about customizing your Jekyll theme, as well as basic Jekyll usage documentation at [jekyllrb.com](http://jekyllrb.com/)


### PR DESCRIPTION
Navigation by default will show pages that shouldn't be in nav, like 404, this creates a `nav: true` key so that users explicitly add pages to the navigation