### PR TITLE
various fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 _site
 .sass-cache
-node_modules/
-npm-debug.log
+_sass/vanilla-framework/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "_sass/vanilla-framework"]
 	path = _sass/vanilla-framework
 	url = https://github.com/ubuntudesign/vanilla-framework.git
-	branch = v0.0.55

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Port of Vanilla framework to Jekyll theme.
 Run the site as follows (depends on [vanilla-framework](https://github.com/ubuntudesign/vanilla-framework)):
 
 ```
+git submodule init    # Initializes submodule
 git submodule update  # Creates _sass/vanilla-framework
 jekyll serve          # Run the site locally
 ```


### PR DESCRIPTION
# various fixes that i came up with while using jekyll-vanilla-theme

### .gitgignore
 removed node stuff and added relevant ignore path for theme

### .gitmodules
 branch defaults to latest if not specified 

### README.md
 fixed setup info
